### PR TITLE
Do not update the tag when data corruption found

### DIFF
--- a/cshatag.c
+++ b/cshatag.c
@@ -255,7 +255,6 @@ int main(int argc, const char* argv[])
                 fprintf(stderr, "Error: corrupt file \"%s\"\n", fn);
                 printf("<corrupt> %s\n", fn);
                 printf(" stored: %s\n actual: %s\n", formatxa(s), formatxa(a));
-                needsupdate = 1;
                 havecorrupt = 1;
             }
         } else


### PR DESCRIPTION
Once data corruption has been found, deliberate user action must be required
(restore from backup or manual tag reset). Otherwise, corruption could easily
be missed since a subsequent run of `cshatag` would return `<ok>`.