### PR TITLE
WIP Feature/macos compatibility

### DIFF
--- a/cshatag.c
+++ b/cshatag.c
@@ -32,6 +32,14 @@
 #define SHA256_BYTES 32
 #define SHA256_NIBBLES 64
 
+#ifdef __APPLE__
+#define st_mtim st_mtimespec
+#define fgetxattr(fd, name, buf, size) fgetxattr(fd, name, buf, size, 0, 0)
+#define fsetxattr(fd, name, buf, size, flags) fsetxattr(fd, name, buf, size, 0, flags)
+#undef ENODATA
+#define ENODATA ENOATTR
+#endif
+
 /**
  * Holds a file's metadata
  */

--- a/cshatag.c
+++ b/cshatag.c
@@ -35,7 +35,13 @@
 #ifdef __APPLE__
 #define st_mtim st_mtimespec
 #define fgetxattr(fd, name, buf, size) fgetxattr(fd, name, buf, size, 0, 0)
-#define fsetxattr(fd, name, buf, size, flags) fsetxattr(fd, name, buf, size, 0, flags)
+/*
+ * SMB or MacOS bug: when working on an SMB mounted filesystem on a Mac, it seems the call
+ * to `fsetxattr` does not update the xattr but removes it instead. So it takes two runs
+ * of `cshatag` to update the attribute.
+ * To work around this issue, we remove the xattr explicitely before setting it again.
+ */
+#define fsetxattr(fd, name, buf, size, flags) fremovexattr(fd, name, 0)|fsetxattr(fd, name, buf, size, 0, flags)
 #undef ENODATA
 #define ENODATA ENOATTR
 #endif

--- a/cshatag.c
+++ b/cshatag.c
@@ -39,9 +39,10 @@
  * SMB or MacOS bug: when working on an SMB mounted filesystem on a Mac, it seems the call
  * to `fsetxattr` does not update the xattr but removes it instead. So it takes two runs
  * of `cshatag` to update the attribute.
- * To work around this issue, we remove the xattr explicitely before setting it again.
+ * To work around this issue, we call `fsetxattr` twice ourselves.
  */
-#define fsetxattr(fd, name, buf, size, flags) fremovexattr(fd, name, 0)|fsetxattr(fd, name, buf, size, 0, flags)
+#define fsetxattr(fd, name, buf, size, flags) fsetxattr(fd, name, buf, size, 0, flags) \
+                                              | fsetxattr(fd, name, buf, size, 0, flags)
 #undef ENODATA
 #define ENODATA ENOATTR
 #endif


### PR DESCRIPTION
Do not merge yet:

The current workaround for the MacOS + SMB bug works, but it causes an error to be displayed:

```
$ cshatag test.bin
<outdated> test.bin
 stored: 0000000000000000000000000000000000000000000000000000000000000000 0000000000.000000000
 actual: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1560090071.529093717
Error: could not write extended attributes to file "test.bin": Attribute not found
```

My C is really rusty... Can you suggest a better way to implement it?