### PR TITLE
Adding -remove and -help command-line flags

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 foo.txt
 *.out
+*.err

--- a/tests/3.expected
+++ b/tests/3.expected
@@ -1,0 +1,1 @@
+<removed xattr> foo.txt

--- a/tests/4.expected
+++ b/tests/4.expected
@@ -1,0 +1,1 @@
+Error: xattr.FRemove foo.txt user.shatag.ts: no data available  xattr.FRemove foo.txt user.shatag.sha256: no data available

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -65,4 +65,21 @@ if [[ $RES -eq 0 ]]; then
 	exit 1
 fi
 
+echo "*** Testing removal of extended attributes ***"
+rm -f foo.txt
+TZ=CET touch -t 201901010000 foo.txt
+../cshatag foo.txt > 1.out
+diff -u 1.expected 1.out
+../cshatag --remove foo.txt > 3.out
+diff -u 3.expected 3.out
+set +e
+../cshatag --remove foo.txt 2> 4.err
+RES=$?
+set -e
+if [[ $RES -eq 0 ]]; then
+	echo "should have returned an error code, but returned 0"
+	exit 1
+fi
+diff -u 4.expected 4.err
+
 echo "*** ALL TESTS PASSED ***"


### PR DESCRIPTION
I've been using cshatag for a while and thought I'd tried my hand at providing feature request #5.

Using the flags package gives a '-help' flag which displays usage. This requires some alteration of the code for parsing args.

I've also added a '-remove' flag which calls `removeAttr` to remove the extended attributes from the file argument(s).

Example use:

Tag a file:
```
$ cshatag foo.txt 
<outdated> foo.txt
 stored: 0000000000000000000000000000000000000000000000000000000000000000 0000000000.000000000
 actual: 181210f8f9c779c26da1d9b2075bde0127302ee0e3fca38c9a83f5b1dd8e5d3b 1573057266.617003539
```
Remove a tag:
```
$ cshatag -remove foo.txt 
<removed xattr> foo.txt
```

Subsequent attempts at removal write to stderr:
```
$ cshatag -remove foo.txt 
Error: xattr.FRemove foo.txt user.shatag.ts: no data available  xattr.FRemove foo.txt user.shatag.sha256: no data available
```



