### PR TITLE
Do not update corrupted files hash by default

### DIFF
--- a/check.go
+++ b/check.go
@@ -191,10 +191,17 @@ func checkFile(fn string) {
 		}
 		stats.outdated++
 	}
+
 	if !args.qq {
 		printComparison(stored, actual)
 	}
-	err = storeAttr(f, actual)
+
+	// Only update the stored attribute if it is not corrupted **OR**
+	// if argument 'corruptupdate' been given.
+	if stored.ts != actual.ts || args.corruptupdate {
+		err = storeAttr(f, actual)
+	}
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		stats.errorsWritingXattr++

--- a/cshatag.1
+++ b/cshatag.1
@@ -47,15 +47,17 @@ rewritten in Go in 2019.
 
 .SH OPTIONS
 
--dry-run    don't make any changes
+-dry-run       don't make any changes
 .br
--recursive  recursively process the contents of directories
+-recursive     recursively process the contents of directories
 .br
--remove     remove cshatag's xattrs from FILE
+-remove        remove cshatag's xattrs from FILE
 .br
--q          quiet mode - don't report <ok> files
+-q             quiet mode - don't report <ok> files
 .br
--qq         quiet2 mode - only report <corrupt> files and errors
+-qq            quiet2 mode - only report <corrupt> files and errors
+.br
+-corruptupdate For any corrupted files found update the stored CRC
 
 .SH EXAMPLES
 

--- a/main.go
+++ b/main.go
@@ -25,11 +25,12 @@ var stats struct {
 }
 
 var args struct {
-	remove    bool
-	recursive bool
-	q         bool
-	qq        bool
-	dryrun    bool
+	remove        bool
+	recursive     bool
+	q             bool
+	qq            bool
+	dryrun        bool
+	corruptupdate bool
 }
 
 // walkFn is used when `cshatag` is called with the `--recursive` option. It is the function called
@@ -84,6 +85,7 @@ func main() {
 	flag.BoolVar(&args.recursive, "recursive", false, "Recursively descend into subdirectories. "+
 		"Symbolic links are not followed.")
 	flag.BoolVar(&args.dryrun, "dry-run", false, "don't make any changes")
+	flag.BoolVar(&args.corruptupdate, "corruptupdate", false, "For any corrupted files found update the stored CRC.")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "%s %s\n", myname, GitVersion)
 		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] FILE [FILE2 ...]\n", myname)


### PR DESCRIPTION
Do not update corrupted files hashes unless new `--corruptupdate` flag is provided

Fixes https://github.com/rfjakob/cshatag/issues/26